### PR TITLE
pass servicetype to watcher

### DIFF
--- a/src/DiscoveryClient.coffee
+++ b/src/DiscoveryClient.coffee
@@ -85,7 +85,7 @@ class DiscoveryClient
     @announcementIndex.findAll service
 
   connect: (callback) =>
-    @discoveryWatcher.watch @host
+    @discoveryWatcher.watch @host, @_serviceType
       .spread @saveUpdates
       .then () =>
         @polling = true
@@ -100,7 +100,7 @@ class DiscoveryClient
 
   reconnect: () =>
     Utils.promiseRetry () =>
-      @discoveryWatcher.watch @host
+      @discoveryWatcher.watch @host, @_serviceType
         .spread (statusCode, updates) =>
           @saveUpdates statusCode, updates
           @announcementIndex.getDiscoveryServers()
@@ -174,7 +174,7 @@ class DiscoveryClient
   poll: () =>
     @serverList.getRandom()
       .then (server) =>
-        @discoveryWatcher.watch server, @serviceType, @announcementIndex.index + 1
+        @discoveryWatcher.watch server, @_serviceType, @announcementIndex.index + 1
           .spread (statusCode, update) =>
             if statusCode isnt 204
               @saveUpdates statusCode, update

--- a/test/unit/DiscoveryWatcherSpec.coffee
+++ b/test/unit/DiscoveryWatcherSpec.coffee
@@ -21,7 +21,7 @@ describe "DiscoveryWatcher", ->
     nock.cleanAll()
 
   it "watches with just a server using uri or hostname", (done) ->
-    
+
     watchfunc = (server) =>
       watch =
       nock("http://" + @discoveryServer)
@@ -76,7 +76,7 @@ describe "DiscoveryWatcher", ->
         watch.done()
         done()
 
-   it "aborts", (done) ->
+  it "aborts", (done) ->
     this.timeout 250 # make sure we timeout before the delay
     watch =
       nock "http://" + @discoveryServer


### PR DESCRIPTION
Without it, the discovery-server won't return remote announcements. This is [by design](https://github.com/opentable/service-discovery/blob/master/docs/api.md#watch)